### PR TITLE
Set lido dv exit version

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -2,13 +2,13 @@
   "name": "obol-lido-ejector-holesky.dnp.dappnode.eth",
   "version": "0.1.0",
   "upstreamArg": ["DV_EXIT_VERSION", "EJECTOR_VERSION"],
-  "upstreamVersion": ["e8bee1f", "1.5.0"],
+  "upstreamVersion": ["v0.1.0", "1.5.0"],
   "upstreamRepo": ["ObolNetwork/lido-dv-exit", "lidofinance/validator-ejector"],
   "shortDescription": "Lido validator ejector for Holesky",
   "description": "Lido validator ejector for Holesky",
   "type": "service",
   "author": "DAppNode Association <admin@dappnode.io> (https://github.com/dappnode)",
-  "categories": ["ETH2.0", "Lido", "DVT"],
+  "categories": ["ETH2.0"],
   "links": {
     "homepage": "https://obol.tech/"
   },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     build:
       context: lido-dv-exit
       args:
-        LIDO_DV_EXIT_VERSION: e8bee1f
+        LIDO_DV_EXIT_VERSION: v0.1.0
         NETWORK: holesky
     environment:
       LOG_LEVEL: info


### PR DESCRIPTION
Set lido-dv-exit upstream release version to `v0.1.0` instead of commit hash