### PR TITLE
bump lidofinance/validator-ejector to 1.6.0, ObolNetwork/lido-dv-exit to v0.1.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: validator-ejector
       args:
-        EJECTOR_VERSION: 1.5.0
+        EJECTOR_VERSION: 1.6.0
         NETWORK: holesky
     environment:
       OPERATOR_ID: ""


### PR DESCRIPTION
Bumps upstream version

- [lidofinance/validator-ejector](https://github.com/lidofinance/validator-ejector) from 1.6.0 to [1.6.0](https://github.com/lidofinance/validator-ejector/releases/tag/1.6.0)
- [ObolNetwork/lido-dv-exit](https://github.com/ObolNetwork/lido-dv-exit) from v0.1.0 to [v0.1.0](https://github.com/ObolNetwork/lido-dv-exit/releases/tag/v0.1.0)